### PR TITLE
Add requirements file and reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,10 +347,7 @@ metrics = calculate_performance_metrics(trials_df)
 ## Dependencies
 
 - Python 3.6+
-- pandas
-- numpy
-- h5py
-- tables (pytables)
+- Runtime Python packages are listed in [`requirements.txt`](requirements.txt) and include core libraries such as pandas, numpy, scipy, matplotlib, seaborn, h5py, and tables (PyTables).
 
 ## Installation
 
@@ -360,7 +357,7 @@ git clone https://github.com/your-org/DELTA_Behavior.git
 cd DELTA_Behavior
 
 # Install dependencies
-pip install pandas numpy h5py tables
+pip install -r requirements.txt
 ```
 
 ## Notes

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+h5py
+matplotlib
+numpy
+pandas
+scipy
+seaborn
+tables


### PR DESCRIPTION
## Summary
- add a consolidated requirements.txt capturing the runtime Python dependencies used by the project
- update the README to reference the new requirements file in the dependencies and installation sections

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d6dfa07d5c8326a060c8308e09a9f6